### PR TITLE
StageClear保存導線追加とGame終了時Overlay破棄例外の修正

### DIFF
--- a/tsukuruGame/Assets/Scripts/Game/Application/Flow/StageClearUseCase.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Application/Flow/StageClearUseCase.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using Game.Contracts.MasterData;
+using Game.Contracts.MasterData.Models;
+using Game.Contracts.Save;
+using Game.Contracts.Save.Models;
+using Game.Domain.Save;
+
+namespace Game.Application.Flow
+{
+    /// <summary>
+    /// ステージクリア結果をSaveDataへ反映し、次ステージ解放を行う。
+    /// </summary>
+    public sealed class StageClearUseCase
+    {
+        private readonly ISaveRepository _saveRepository;
+        private readonly IMasterDataRepository _masterDataRepository;
+
+        public StageClearUseCase(
+            ISaveRepository saveRepository,
+            IMasterDataRepository masterDataRepository)
+        {
+            _saveRepository = saveRepository ?? throw new ArgumentNullException(nameof(saveRepository));
+            _masterDataRepository = masterDataRepository ?? throw new ArgumentNullException(nameof(masterDataRepository));
+        }
+
+        public void SaveStageClear(string stageId, string clearRank)
+        {
+            if (string.IsNullOrWhiteSpace(stageId))
+                throw new ArgumentException("stageId is null or empty.", nameof(stageId));
+
+            StageRank clearedRank = ParseRankOrThrow(clearRank, nameof(clearRank));
+
+            // 対象ステージがマスターに存在することを先に保証する。
+            _ = _masterDataRepository.GetStage(stageId);
+
+            SaveDataContract save = _saveRepository.LoadOrCreateDefault() ?? new SaveDataContract();
+            if (save.Stages == null)
+                save.Stages = new List<StageProgressContract>();
+
+            UpsertClearedStage(save.Stages, stageId, clearedRank);
+            UnlockNextStage(save.Stages, stageId);
+
+            _saveRepository.Save(save);
+        }
+
+        private void UnlockNextStage(List<StageProgressContract> progresses, string currentStageId)
+        {
+            IReadOnlyList<StageDefinitionContract> allStages = _masterDataRepository.GetAllStages();
+            if (allStages == null || allStages.Count == 0)
+                return;
+
+            List<StageDefinitionContract> ordered = new List<StageDefinitionContract>(allStages.Count);
+            for (int i = 0; i < allStages.Count; i++)
+            {
+                StageDefinitionContract stage = allStages[i];
+                if (stage == null)
+                    continue;
+
+                ordered.Add(stage);
+            }
+
+            ordered.Sort(CompareStageOrder);
+            int currentIndex = FindStageIndexById(ordered, currentStageId);
+            if (currentIndex < 0)
+                throw new InvalidOperationException($"Current stage is not found in master stages: {currentStageId}");
+
+            int nextIndex = currentIndex + 1;
+            if (nextIndex >= ordered.Count)
+                return;
+
+            string nextStageId = ordered[nextIndex].Id;
+            StageProgressContract nextProgress = FindOrCreateProgress(progresses, nextStageId);
+            nextProgress.Unlocked = true;
+        }
+
+        private static int CompareStageOrder(StageDefinitionContract x, StageDefinitionContract y)
+        {
+            if (ReferenceEquals(x, y))
+                return 0;
+            if (x == null)
+                return -1;
+            if (y == null)
+                return 1;
+
+            int byOrder = x.OrderIndex.CompareTo(y.OrderIndex);
+            if (byOrder != 0)
+                return byOrder;
+
+            return string.CompareOrdinal(x.Id, y.Id);
+        }
+
+        private static int FindStageIndexById(IReadOnlyList<StageDefinitionContract> orderedStages, string stageId)
+        {
+            for (int i = 0; i < orderedStages.Count; i++)
+            {
+                StageDefinitionContract stage = orderedStages[i];
+                if (stage != null && string.Equals(stage.Id, stageId, StringComparison.Ordinal))
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static void UpsertClearedStage(
+            List<StageProgressContract> progresses,
+            string stageId,
+            StageRank clearedRank)
+        {
+            StageProgressContract progress = FindOrCreateProgress(progresses, stageId);
+            progress.Unlocked = true;
+            progress.Cleared = true;
+
+            StageRank currentBest = ParseRankOrNone(progress.BestRank);
+            if (clearedRank > currentBest)
+                progress.BestRank = ToRankString(clearedRank);
+        }
+
+        private static StageProgressContract FindOrCreateProgress(List<StageProgressContract> progresses, string stageId)
+        {
+            for (int i = 0; i < progresses.Count; i++)
+            {
+                StageProgressContract progress = progresses[i];
+                if (progress == null)
+                    continue;
+
+                if (string.Equals(progress.StageId, stageId, StringComparison.Ordinal))
+                    return progress;
+            }
+
+            StageProgressContract created = new StageProgressContract
+            {
+                StageId = stageId,
+                Unlocked = false,
+                Cleared = false,
+                BestRank = string.Empty,
+            };
+
+            progresses.Add(created);
+            return created;
+        }
+
+        private static StageRank ParseRankOrThrow(string rankText, string paramName)
+        {
+            if (string.IsNullOrWhiteSpace(rankText))
+                throw new ArgumentException("rank is null or empty.", paramName);
+
+            StageRank rank = ParseRankOrNone(rankText);
+            if (rank == StageRank.None)
+                throw new ArgumentException($"Unsupported clear rank: {rankText}", paramName);
+
+            return rank;
+        }
+
+        private static StageRank ParseRankOrNone(string rankText)
+        {
+            if (string.IsNullOrWhiteSpace(rankText))
+                return StageRank.None;
+
+            string normalized = rankText.Trim().ToUpperInvariant();
+            if (normalized == "C")
+                return StageRank.C;
+            if (normalized == "B")
+                return StageRank.B;
+            if (normalized == "A")
+                return StageRank.A;
+            if (normalized == "S")
+                return StageRank.S;
+
+            return StageRank.None;
+        }
+
+        private static string ToRankString(StageRank rank)
+        {
+            if (rank == StageRank.C)
+                return "C";
+            if (rank == StageRank.B)
+                return "B";
+            if (rank == StageRank.A)
+                return "A";
+            if (rank == StageRank.S)
+                return "S";
+
+            return string.Empty;
+        }
+    }
+}

--- a/tsukuruGame/Assets/Scripts/Game/Application/Flow/StageClearUseCase.cs.meta
+++ b/tsukuruGame/Assets/Scripts/Game/Application/Flow/StageClearUseCase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 305aef3b84da5f9448016c0f067c3b08

--- a/tsukuruGame/Assets/Scripts/Game/Presentation/Boot/BootEntryPoint.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Presentation/Boot/BootEntryPoint.cs
@@ -151,9 +151,11 @@ namespace Game.Presentation.Boot
             ISceneLoader sceneLoader = new UnitySceneLoader(titleSceneName, gameSceneName);
 
             GameFlowUseCase flowUseCase = new GameFlowUseCase(gameSession, masterDataRepository, sceneLoader);
+            StageClearUseCase stageClearUseCase = new StageClearUseCase(saveRepository, masterDataRepository);
             OptionUseCase optionUseCase = new OptionUseCase(saveRepository, settingsApplier);
             GameServices services = new GameServices(
                 flowUseCase,
+                stageClearUseCase,
                 optionUseCase,
                 gameSession,
                 saveRepository,

--- a/tsukuruGame/Assets/Scripts/Game/Presentation/Common/GameServices.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Presentation/Common/GameServices.cs
@@ -12,6 +12,8 @@ namespace Game.Presentation.Common
     {
         public GameFlowUseCase GameFlowUseCase { get; }
 
+        public StageClearUseCase StageClearUseCase { get; }
+
         public OptionUseCase OptionUseCase { get; }
 
         public GameSession GameSession { get; }
@@ -24,6 +26,7 @@ namespace Game.Presentation.Common
 
         public GameServices(
             GameFlowUseCase gameFlowUseCase,
+            StageClearUseCase stageClearUseCase,
             OptionUseCase optionUseCase,
             GameSession gameSession,
             ISaveRepository saveRepository,
@@ -31,6 +34,7 @@ namespace Game.Presentation.Common
             IMasterDataRepository masterDataRepository)
         {
             GameFlowUseCase = gameFlowUseCase ?? throw new ArgumentNullException(nameof(gameFlowUseCase));
+            StageClearUseCase = stageClearUseCase ?? throw new ArgumentNullException(nameof(stageClearUseCase));
             OptionUseCase = optionUseCase ?? throw new ArgumentNullException(nameof(optionUseCase));
             GameSession = gameSession ?? throw new ArgumentNullException(nameof(gameSession));
             SaveRepository = saveRepository ?? throw new ArgumentNullException(nameof(saveRepository));

--- a/tsukuruGame/Assets/Scripts/Game/Presentation/Game/GameSceneEntryPoint.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Presentation/Game/GameSceneEntryPoint.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Game.Contracts.MasterData.Models;
 using Game.Domain.Battle;
 using Game.Domain.GameSession;
@@ -14,6 +14,7 @@ namespace Game.Presentation.Game
     public sealed class GameSceneEntryPoint : MonoBehaviour
     {
         private const string DefaultBossId = "boss_01";
+        private const string DefaultClearRank = "C";
 
         [SerializeField] private GameHudView gameHudView;
         [SerializeField] private BossTitleOverlayView bossTitleOverlayView;
@@ -87,26 +88,22 @@ namespace Game.Presentation.Game
         {
             if (_gameHudPresenter != null)
             {
-                _gameHudPresenter.Hide();
                 _gameHudPresenter.Dispose();
             }
 
             if (_gameHudPresenter != null && gameHudView != null)
             {
-                gameHudView.Hide();
                 gameHudView.Unbind();
             }
 
             if (_bossTitleOverlayPresenter != null)
             {
                 _bossTitleOverlayPresenter.Finished -= OnBossTitleOverlayFinished;
-                _bossTitleOverlayPresenter.ForceHide();
                 _bossTitleOverlayPresenter.Dispose();
             }
 
             if (_bossTitleOverlayPresenter != null && bossTitleOverlayView != null)
             {
-                bossTitleOverlayView.Hide();
                 bossTitleOverlayView.Unbind();
             }
 
@@ -266,6 +263,11 @@ namespace Game.Presentation.Game
 
             HideGameHud();
             _isExiting = true;
+            string clearedStageId = _session != null ? _session.CurrentStageId : string.Empty;
+            if (string.IsNullOrWhiteSpace(clearedStageId))
+                throw new InvalidOperationException("Current stage id is empty at exit.");
+
+            _services.StageClearUseCase.SaveStageClear(clearedStageId, DefaultClearRank);
             _services.GameFlowUseCase.ReturnToTitleWithStageSelect();
             _flowState = FlowState.Completed;
         }

--- a/tsukuruGame/Assets/Scripts/Game/Presentation/TestScenes/BossFlowTestSceneBootstrap.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Presentation/TestScenes/BossFlowTestSceneBootstrap.cs
@@ -53,9 +53,11 @@ namespace Game.Presentation.TestScenes
             SettingsApplier = new NoOpSettingsApplier();
 
             GameFlowUseCase flowUseCase = new GameFlowUseCase(session, masterDataRepository, SceneLoader);
+            StageClearUseCase stageClearUseCase = new StageClearUseCase(SaveRepository, masterDataRepository);
             OptionUseCase optionUseCase = new OptionUseCase(SaveRepository, SettingsApplier);
             GameServices services = new GameServices(
                 flowUseCase,
+                stageClearUseCase,
                 optionUseCase,
                 session,
                 SaveRepository,


### PR DESCRIPTION
 ## 関連Issue
  - Closes #30

  ## 目的
  - BattleEnd時にステージ進行を保存する導線を追加し、StageSelectへ解放状態を反映できるようにする。
  - Game終了時に `BossTitleOverlayView.root is not assigned` が出る後片付け例外を解消する。

  ## 変更内容
  - `StageClearUseCase` を追加
  - BattleEnd時にクリア結果を保存する導線を `GameSceneEntryPoint` に追加
  - `GameServices` に `StageClearUseCase` を追加し、Boot/TestScene のDI配線を更新
  - `OnDestroy` 中の `Hide/ForceHide` 呼び出しをやめ、`Dispose/Unbind` のみに変更

  ## 仕様（今回の確定）
  - クリアランクは暫定で `C` 固定保存
  - 保存時に以下を更新
  - クリアしたステージ: `Unlocked=true`, `Cleared=true`, `BestRank` 更新
  - 次ステージ（`OrderIndex`順で1つ先）: `Unlocked=true`
  - `BestRank` は高いランクのみ上書き（`S > A > B > C`）

  ## 変更ファイル
  - `Assets/Scripts/Game/Application/Flow/StageClearUseCase.cs`
  - `Assets/Scripts/Game/Presentation/Game/GameSceneEntryPoint.cs`
  - `Assets/Scripts/Game/Presentation/Common/GameServices.cs`
  - `Assets/Scripts/Game/Presentation/Boot/BootEntryPoint.cs`
  - `Assets/Scripts/Game/Presentation/TestScenes/BossFlowTestSceneBootstrap.cs`

  ## 動作確認
  - `stage_01` クリア後にTitleへ戻る
  - StageSelectで `stage_01` のクリア状態と `stage_02` の解放状態が反映されることを確認
  - Game終了時に `BossTitleOverlayView.root is not assigned` 例外が発生しないことを確認

  ## 影響範囲
  - GameScene終了導線
  - Runtimeサービス初期化（Boot/TestScene）
  - SaveDataのステージ進行更新

  ## 補足
  - ランク算出ロジック本体は未対応（暫定固定）
  - StageClearResult UI（S42）は未対応