### PR TITLE
  BOSS-01 ボス行動ループ基盤を追加

### DIFF
--- a/tsukuruGame/Assets/Scripts/Game/Contracts/MasterData/BossParamsContract.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Contracts/MasterData/BossParamsContract.cs
@@ -15,5 +15,7 @@ namespace Game.Contracts.MasterData.Models
         public int BaseDropEnergyAmount { get; set; }
 
         public float MinDropIntervalSeconds { get; set; }
+
+        public float ActionIntervalSeconds { get; set; }
     }
 }

--- a/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionService.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionService.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using Game.Contracts.MasterData.Models;
+
+namespace Game.Domain.Battle
+{
+    /// <summary>
+    /// Produces boss action spawn requests on a timer while in Combat.
+    /// </summary>
+    public sealed class BossActionService
+    {
+        private static readonly IReadOnlyList<BossActionSpawnRequest> EmptyRequests = Array.Empty<BossActionSpawnRequest>();
+
+        private Boss _boss;
+        private float _actionIntervalSeconds;
+        private float _elapsedSeconds;
+        private bool _isInitialized;
+
+        public void Initialize(Boss boss, BossParamsContract bossParams)
+        {
+            if (boss == null)
+                throw new ArgumentNullException(nameof(boss));
+            if (bossParams == null)
+                throw new ArgumentNullException(nameof(bossParams));
+            if (bossParams.ActionIntervalSeconds <= 0f)
+                throw new InvalidOperationException(
+                    $"Boss action interval must be positive. actionIntervalSeconds={bossParams.ActionIntervalSeconds}");
+
+            _boss = boss;
+            _actionIntervalSeconds = bossParams.ActionIntervalSeconds;
+            _elapsedSeconds = 0f;
+            _isInitialized = true;
+        }
+
+        public IReadOnlyList<BossActionSpawnRequest> Update(BattleContext context, float deltaTime)
+        {
+            EnsureInitialized();
+
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            if (context.Boss == null)
+                throw new InvalidOperationException("BattleContext.Boss is not initialized.");
+            if (!ReferenceEquals(context.Boss, _boss))
+                throw new InvalidOperationException("BattleContext.Boss does not match initialized boss.");
+
+            if (context.Phase != BattlePhase.Combat)
+                return EmptyRequests;
+            if (context.Boss.IsAllGaugesEmpty())
+                return EmptyRequests;
+            if (deltaTime <= 0f)
+                return EmptyRequests;
+
+            _elapsedSeconds += deltaTime;
+            if (_elapsedSeconds < _actionIntervalSeconds)
+                return EmptyRequests;
+
+            int fireCount = (int)Math.Floor(_elapsedSeconds / _actionIntervalSeconds);
+            _elapsedSeconds -= fireCount * _actionIntervalSeconds;
+
+            int phaseIndex = context.Boss.GetCurrentGaugeIndex();
+            List<BossActionSpawnRequest> requests = new List<BossActionSpawnRequest>(fireCount);
+            for (int i = 0; i < fireCount; i++)
+            {
+                requests.Add(
+                    new BossActionSpawnRequest(
+                        phaseIndex: phaseIndex,
+                        spawnCount: 1,
+                        intervalSeconds: _actionIntervalSeconds));
+            }
+
+            return requests;
+        }
+
+        public void Reset()
+        {
+            _elapsedSeconds = 0f;
+        }
+
+        private void EnsureInitialized()
+        {
+            if (!_isInitialized)
+                throw new InvalidOperationException("BossActionService is not initialized.");
+        }
+    }
+}

--- a/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionService.cs.meta
+++ b/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e3c107378bff0941875aaee04a329e5

--- a/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionSpawnRequest.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionSpawnRequest.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Game.Domain.Battle
+{
+    /// <summary>
+    /// Minimal spawn request payload produced by BossActionService.
+    /// </summary>
+    public readonly struct BossActionSpawnRequest
+    {
+        public BossActionSpawnRequest(int phaseIndex, int spawnCount, float intervalSeconds)
+        {
+            if (phaseIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(phaseIndex), "phaseIndex must be non-negative.");
+            if (spawnCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(spawnCount), "spawnCount must be positive.");
+            if (intervalSeconds <= 0f)
+                throw new ArgumentOutOfRangeException(nameof(intervalSeconds), "intervalSeconds must be positive.");
+
+            PhaseIndex = phaseIndex;
+            SpawnCount = spawnCount;
+            IntervalSeconds = intervalSeconds;
+        }
+
+        public int PhaseIndex { get; }
+
+        public int SpawnCount { get; }
+
+        public float IntervalSeconds { get; }
+    }
+}

--- a/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionSpawnRequest.cs.meta
+++ b/tsukuruGame/Assets/Scripts/Game/Domain/Battle/BossActionSpawnRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fb879d4a6324ca740bab49474b594baf

--- a/tsukuruGame/Assets/Scripts/Game/Infrastructure/MasterData/Assets/BossParamsAsset.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Infrastructure/MasterData/Assets/BossParamsAsset.cs
@@ -10,10 +10,12 @@ namespace Game.Infrastructure.MasterData.Assets
         [SerializeField] private List<int> gaugeMaxHps = new List<int>();
         [SerializeField] private int baseDropEnergyAmount;
         [SerializeField] private float minDropIntervalSeconds;
+        [SerializeField] private float actionIntervalSeconds = 1.0f;
 
         public string Id => id;
         public IReadOnlyList<int> GaugeMaxHps => gaugeMaxHps;
         public int BaseDropEnergyAmount => baseDropEnergyAmount;
         public float MinDropIntervalSeconds => minDropIntervalSeconds;
+        public float ActionIntervalSeconds => actionIntervalSeconds;
     }
 }

--- a/tsukuruGame/Assets/Scripts/Game/Infrastructure/MasterData/Mapping/MasterDataMapper.cs
+++ b/tsukuruGame/Assets/Scripts/Game/Infrastructure/MasterData/Mapping/MasterDataMapper.cs
@@ -57,6 +57,7 @@ namespace Game.Infrastructure.MasterData.Mapping
                 GaugeMaxHps = gauges,
                 BaseDropEnergyAmount = asset.BaseDropEnergyAmount,
                 MinDropIntervalSeconds = asset.MinDropIntervalSeconds,
+                ActionIntervalSeconds = asset.ActionIntervalSeconds,
             };
         }
 


### PR DESCRIPTION
  - `BossActionService` を追加
    - `Initialize(Boss, BossParamsContract)`
    - `Update(BattleContext, float)`（Combat中のみ要求を返却）
    - `Reset()`
  - `BossActionSpawnRequest` を追加（phaseIndex/spawnCount/intervalSeconds）
  - `BossParamsContract` に `ActionIntervalSeconds` を追加
  - `BossParamsAsset` に `actionIntervalSeconds` を追加
  - `MasterDataMapper` で `ActionIntervalSeconds` を Contract へマッピング

  ## 仕様対応
  - BOSS-01: ボス行動ループ最小実装（SpawnRequest返却）
  - Combat外では発火しない
  - ボス撃破後は発火しない
  - 大きい `deltaTime` での複数回発火に対応

  ## 動作確認
  - コード確認のみ（Unityでの実行確認・テスト実行は未実施）

  ## 影響範囲
  - `Assets/Scripts/Game/Domain/Battle`
  - `Assets/Scripts/Game/Contracts/MasterData`
  - `Assets/Scripts/Game/Infrastructure/MasterData`

  ## 関連
  - Issue: `BOSS-01`
  - Spec: `blueprints/07_IMPLEMENTATION_PLAN.md`（6.4/6.6）